### PR TITLE
Fix/eq ne sort urls before assertion

### DIFF
--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -351,6 +351,12 @@ class Document(object):
         other_doc.__dict__['urls'] = sorted(other_doc.__dict__['urls'])
         return self._doc != other_doc._doc
 
+    def __lt__(self, other_doc):
+        return self.did < other_doc.did
+
+    def __gt__(self, other_doc):
+        return self.did > other_doc.did
+
     def __repr__(self):
         """
         String representation of a Document

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -330,9 +330,25 @@ class Document(object):
         self._load(json)
 
     def __eq__(self, other_doc):
+        """
+        equals `==` operator overload
+
+        It doesn't matter the order of the urls list. What matters is the
+        existence of the urls are the same on both sides.
+        """
+        self.__dict__['urls'] = sorted(self.__dict__['urls'])
+        other_doc.__dict__['urls'] = sorted(other_doc.__dict__['urls'])
         return self._doc == other_doc._doc
 
     def __ne__(self, other_doc):
+        """
+        not equals `!=` operator overload
+
+        It doesn't matter the order of the urls list. What matters is the
+        existence of the urls are the same on both sides.
+        """
+        self.__dict__['urls'] = sorted(self.__dict__['urls'])
+        other_doc.__dict__['urls'] = sorted(other_doc.__dict__['urls'])
         return self._doc != other_doc._doc
 
     def __repr__(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -79,9 +79,6 @@ def test_list_with_params_negate(index_client):
     assert dids == {doc1.did}
 
 
-
-
-
 def test_get_latest_version(index_client):
     """
     Args:

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,0 +1,77 @@
+import pytest
+
+from indexclient.client import Document, recursive_sort
+
+
+def create_document(
+        did=None, hashes=None, size=None, file_name=None, acl=None,
+        urls=None, urls_metadata=None):
+
+    return Document(None, did, json={
+        'hashes': hashes or {},
+        'size': size or 1,
+        'file_name': file_name or 'file.txt',
+        'urls': urls or ['one', 'two', 'three'],
+        'acl': acl or ['1', '2', '3'],
+        'urls_metadata': urls_metadata or {
+            'one': {'1': 'one'},
+            'two': {'2': 'two'},
+            'three': {'3': 'three'},
+        },
+    })
+
+
+def test_equals():
+    doc1 = create_document()
+    doc2 = create_document()
+    assert doc1 == doc2
+
+    # Out of order values are still equal because the contents are the same.
+    doc1.acl = ['4', '5']
+    doc2.acl = ['5', '4']
+    assert doc1 == doc2
+
+
+def test_not_equals():
+    doc1 = create_document(acl=['1', '2'])
+    doc2 = create_document(acl=['2', '3'])
+    assert doc1 != doc2
+
+
+def test_less_than():
+    doc1 = create_document(did='11111111-1111-1111-1111-111111111111')
+    doc2 = create_document(did='11111111-1111-1111-1111-111111111112')
+    assert doc1 < doc2
+
+    # reverse order docs
+    docs = [
+        create_document(did='11111111-1111-1111-1111-11111111111' + str(suffix))
+        for suffix in range(10, 0, -1)
+    ]
+    # sorted() sorts it in order from lowest to highest did because of __lt__/__gt__
+    assert sorted(docs) == docs[::-1]
+
+
+def test_greater_than():
+    doc1 = create_document(did='11111111-1111-1111-1111-111111111111')
+    doc2 = create_document(did='11111111-1111-1111-1111-111111111112')
+    assert doc2 > doc1
+
+    # reverse order docs
+    docs = [
+        create_document(did='11111111-1111-1111-1111-11111111111' + str(suffix))
+        for suffix in range(10, 0, -1)
+    ]
+    # sorted() sorts it in order from lowest to highest did because of __lt__/__gt__
+    assert sorted(docs) == docs[::-1]
+
+
+@pytest.mark.parametrize('given, expected', [
+    (1, 1),
+    ('one', 'one'),
+    ([1, 4, 3, 2], [1, 2, 3, 4]),
+    ({'dict': [1, 4, 3, 2]}, {'dict': [1, 2, 3, 4]}),
+    ({'one': {'two': [1, 4, 3, 2]}}, {'one': {'two': [1, 2, 3, 4]}}),
+])
+def test_recursive_sort(given, expected):
+    assert recursive_sort(given) == expected


### PR DESCRIPTION
Allow for easier comparisons between Document objects.

### New Features
- Implemented `__gt__` and `__lt__` special methods. This allows for lists of Documents to be sorted by `did` using the `sorted()` python function.

### Improvements
- Sort all lists in the `Document._doc` property on `__eq__` and  `__ne__`. Data from the database might be returned out of order but in most cases we want to see that the same data exists on both sides of the operator, not what order it is in.