### PR TITLE
fix(authz): use `authz` instead of `rbac`

### DIFF
--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -12,7 +12,7 @@ MAX_RETRIES = 10
 
 UPDATABLE_ATTRS = [
     'file_name', 'urls', 'version',
-    'metadata', 'acl', 'rbac', 'urls_metadata'
+    'metadata', 'acl', 'authz', 'urls_metadata'
 ]
 
 
@@ -51,6 +51,7 @@ def retry_and_timeout_wrapper(func):
                     raise
 
     return retry_logic_with_timeout
+
 
 class IndexClient(object):
 
@@ -223,7 +224,7 @@ class IndexClient(object):
     def create(
             self, hashes, size, did=None, urls=None, file_name=None,
             metadata=None, baseid=None, acl=None, urls_metadata=None, version=None,
-            rbac=None):
+            authz=None):
         """Create a new entry in indexd
 
         Args:
@@ -233,7 +234,7 @@ class IndexClient(object):
             did (str): provide a UUID for the new indexd to be made
             urls (list): list of URLs where you can download the UUID
             acl (list): access control list
-            rbac (str): RBAC string
+            authz (str): RBAC string
             file_name (str): name of the file associated with a given UUID
             metadata (dict): additional key value metadata for this entry
             urls_metadata (dict): metadata attached to each url
@@ -255,7 +256,7 @@ class IndexClient(object):
             "urls_metadata": urls_metadata,
             "baseid": baseid,
             "acl": acl,
-            "rbac": rbac,
+            "authz": authz,
             "version": version
         }
         if did:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,10 @@
 pytest==3.0.6
 mock
+
+# these are for indexd
+authutils==3.1.0
+gen3rbac==0.1.2
+
 -e git+https://github.com/uc-cdis/cdisutils-test.git@f1eaf101c2ab6dd2d2ad7dc9bb3f98487238a4ad#egg=cdisutilstest
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.1.7#egg=cdispyutils
 -e git+https://github.com/uc-cdis/indexd.git@28fa621a924952be902628cfc5c1186bda38e922#egg=indexd

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,7 @@ mock
 authutils==3.1.0
 gen3rbac==0.1.2
 
--e git+https://github.com/uc-cdis/cdisutils-test.git@f1eaf101c2ab6dd2d2ad7dc9bb3f98487238a4ad#egg=cdisutilstest
+-e git+https://github.com/uc-cdis/cdisutils-test.git@fdc53fb3d5333d53f625f0f0712eaa2fa19c803f#egg=cdisutilstest
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.1.7#egg=cdispyutils
 -e git+https://github.com/uc-cdis/indexd.git@28fa621a924952be902628cfc5c1186bda38e922#egg=indexd
 -e git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ pytest==3.0.6
 mock
 -e git+https://github.com/uc-cdis/cdisutils-test.git@f1eaf101c2ab6dd2d2ad7dc9bb3f98487238a4ad#egg=cdisutilstest
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.1.7#egg=cdispyutils
--e git+https://github.com/uc-cdis/indexd.git@ddc6bfd1e0cd4bbf27bc4ab7a7e00078b4d5c98c#egg=indexd
+-e git+https://github.com/uc-cdis/indexd.git@28fa621a924952be902628cfc5c1186bda38e922#egg=indexd
 -e git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
 -e git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
 -e git+https://github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,7 +12,7 @@ def test_instantiate(index_client):
     urls_metadata={url: {'state': 'doing ok'} for url in urls}
     size = 5
     acl = ['a', 'b']
-    authz = '/gen3/programs/a/projects/b'
+    authz = ['/gen3/programs/a/projects/b']
     hashes = {'md5': 'ab167e49d25b488939b1ede42752458b'}
     doc = index_client.create(
         hashes=hashes,
@@ -38,7 +38,7 @@ def test_create_with_metadata(index_client):
     urls_metadata = {'s3://bucket/key': {'k': 'v'}}
     size = 5
     acl = ['a', 'b']
-    authz = '/gen3/programs/a/projects/b'
+    authz = ['/gen3/programs/a/projects/b']
     hashes = {'md5': 'ab167e49d25b488939b1ede42752458b'}
     metadata = {'test': 'value'}
     doc = index_client.create(
@@ -194,11 +194,11 @@ def test_updating_authz(index_client):
     """
     doc = create_random_index(index_client)
 
-    doc.authz = '/gen3/programs/a'
+    doc.authz = ['/gen3/programs/a']
     doc.patch()
 
     same_doc = index_client.get(doc.did)
-    assert same_doc.authz == '/gen3/programs/a'
+    assert same_doc.authz == ['/gen3/programs/a']
 
 
 def test_bulk_request(index_client):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,14 +12,14 @@ def test_instantiate(index_client):
     urls_metadata={url: {'state': 'doing ok'} for url in urls}
     size = 5
     acl = ['a', 'b']
-    rbac = '/gen3/programs/a/projects/b'
+    authz = '/gen3/programs/a/projects/b'
     hashes = {'md5': 'ab167e49d25b488939b1ede42752458b'}
     doc = index_client.create(
         hashes=hashes,
         size=size,
         urls=urls,
         acl=acl,
-        rbac=rbac,
+        authz=authz,
         baseid=baseid,
         urls_metadata=urls_metadata,
     )
@@ -30,7 +30,7 @@ def test_instantiate(index_client):
     assert doc.baseid == baseid
     assert doc.urls_metadata == urls_metadata
     assert doc.acl == acl
-    assert doc.rbac == rbac
+    assert doc.authz == authz
 
 
 def test_create_with_metadata(index_client):
@@ -38,7 +38,7 @@ def test_create_with_metadata(index_client):
     urls_metadata = {'s3://bucket/key': {'k': 'v'}}
     size = 5
     acl = ['a', 'b']
-    rbac = '/gen3/programs/a/projects/b'
+    authz = '/gen3/programs/a/projects/b'
     hashes = {'md5': 'ab167e49d25b488939b1ede42752458b'}
     metadata = {'test': 'value'}
     doc = index_client.create(
@@ -46,7 +46,7 @@ def test_create_with_metadata(index_client):
         size=size,
         urls=urls,
         acl=acl,
-        rbac=rbac,
+        authz=authz,
         metadata=metadata,
         urls_metadata=urls_metadata,
     )
@@ -187,18 +187,18 @@ def test_updating_acl(index_client):
     assert same_doc.acl == ['a']
 
 
-def test_updating_rbac(index_client):
+def test_updating_authz(index_client):
     """
     Args:
         index_client (indexclient.client.IndexClient): IndexClient Pytest Fixture
     """
     doc = create_random_index(index_client)
 
-    doc.rbac = '/gen3/programs/a'
+    doc.authz = '/gen3/programs/a'
     doc.patch()
 
     same_doc = index_client.get(doc.did)
-    assert same_doc.rbac == '/gen3/programs/a'
+    assert same_doc.authz == '/gen3/programs/a'
 
 
 def test_bulk_request(index_client):

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -4,7 +4,7 @@ from indexclient.client import Document, recursive_sort
 
 
 def create_document(
-        did=None, hashes=None, size=None, file_name=None, acl=None, rbac=None,
+        did=None, hashes=None, size=None, file_name=None, acl=None, authz=None,
         urls=None, urls_metadata=None):
 
     return Document(None, did, json={
@@ -13,7 +13,7 @@ def create_document(
         'file_name': file_name or 'file.txt',
         'urls': urls or ['one', 'two', 'three'],
         'acl': acl or ['1', '2', '3'],
-        'rbac': rbac or '/gen3/programs/1/projects/2/3',
+        'authz': authz or '/gen3/programs/1/projects/2/3',
         'urls_metadata': urls_metadata or {
             'one': {'1': 'one'},
             'two': {'2': 'two'},


### PR DESCRIPTION
### Improvements

- Name field `authz` instead of `rbac` for better clarity & internal consistency.