### PR TITLE
fix urljoin

### DIFF
--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -1,8 +1,3 @@
-try:
-    from urlparse import urljoin
-except ImportError:
-    from urllib.parse import urljoin
-
 import copy
 import json
 
@@ -66,7 +61,8 @@ class IndexClient(object):
         self.version = version
 
     def url_for(self, *path):
-        return urljoin(self.url, "/".join(path))
+        subpath = "/".join(path).lstrip("/")
+        return "{}/{}".format(self.url.rstrip("/"), subpath)
 
     def check_status(self):
         """Check that the API we are trying to communicate with is online"""

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -308,7 +308,7 @@ class IndexClient(object):
                 "keeper_authority": keeper_authority,
             }
         )
-        url = "/alias/" + record
+        url = "alias/" + record
         headers = {"content-type": "application/json"}
         resp = self._put(url, headers=headers, data=data, auth=self.auth)
         return resp.json()


### PR DESCRIPTION
Fix bug with alias path building when we use a custom indexd base URL

```
# before
url = "https://path/to/indexd/"
path = "/alias/something"
urljoin(url, path)
> "https://path/alias/something"

# after
url = "https://path/to/indexd/"
path = "alias/something"
urljoin(url, path)
> "https://path/to/index/alias/something"
```

https://stackoverflow.com/a/10893427

Edit: let's not use urljoin so that it will work in all cases

### Bug Fixes
- Fix bug with alias path building when we use a custom indexd base URL
