### PR TITLE
Feat/new aliases (PXP-4710)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ install:
 - pip install . --force --upgrade
 - pip install -r test-requirements.txt
 script: python -m pytest -vvvs tests
+jobs:
+  allow_failures:
+  - python: '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: python
 python:
-- '2.7'
 - '3.6'
 sudo: false
 install:
 - pip install . --force --upgrade
 - pip install -r test-requirements.txt
 script: python -m pytest -vvvs tests
-jobs:
-  allow_failures:
-  - python: '2.7'

--- a/README.md
+++ b/README.md
@@ -211,11 +211,10 @@ You can use `indexclient` to create aliases for documents in `indexd`, which ena
 Example:
 
 ```python
-try:
-    indexclient.add_alias_for_did("10.1000/182", "g.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e")
-except BaseIndexError as err:
-    # Alias creation failed -- handle error
-    
+res = indexclient.add_alias_for_did("10.1000/182", "g.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e")
+if res.status_code != 200:
+    # alias creation failed -- handle error
+
 doc = indexclient.global_get("10.1000/182")
 print(doc.did) # >> "g.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e"
 ```

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ acl = ["a", "b"]
 Example:
 
 ```python
-indexclient.get(did="dg.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e")  
+indexclient.get("dg.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e")  
 ```
 
 #### Method: `global_get`
@@ -118,11 +118,18 @@ indexclient.get(did="dg.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e")
 Example:
 
 ```python
-indexclient.global_get(did="dg.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e")
+indexclient.global_get("dg.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e")
 ```
 or
 ```python
-indexclient.global_get(did="dg.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e", no_dist=True)
+indexclient.global_get("dg.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e", no_dist=True)
+```
+
+`global_get` can also be used to retrieve records by alias. See [Add an alias for a record](#add-an-alias-for-a-record).
+```python
+# Retrieve a document by its alias, "10.1000/182"
+doc = indexclient.global_get("10.1000/182")
+print(doc.did) # >> "g.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e"
 ```
 
 #### Method: `get_with_params`
@@ -171,7 +178,7 @@ Lastly: Update all the local changes that were made to indexd using the
 Example:
 
 ```python
-doc = indexclient.get(did="dg.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e"')
+doc = indexclient.get("dg.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e"')
 # or any other get method (global_get, etc.)
 doc.metadata["dummy_field"] = "dummy var"
 doc.acl = ['a', 'b']
@@ -190,9 +197,25 @@ Lastly: Check if the record was deleted with: `if doc._deleted`
 Example: 
 
 ```python
-doc = indexclient.get(did="dg.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e")
+doc = indexclient.get("dg.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e")
 # or any other get method (global_get, etc.)
 doc.delete()
 if doc._deleted == False:
 return "Record is not deleted"
+```
+
+### Add an alias for a record
+
+You can use `indexclient` to create aliases for documents in `indexd`, which enable you to retrieve documents by the alias instead of by the Document identifier (`did` / `GUID`). Aliases can be created using `indexclient.add_alias_for_did(alias=alias, did=did)` and can be retrieved using `indexclient.global_get(alias)`.
+
+Example:
+
+```python
+try:
+    indexclient.add_alias_for_did("10.1000/182", "g.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e")
+except BaseIndexError as err:
+    # Alias creation failed -- handle error
+    
+doc = indexclient.global_get("10.1000/182")
+print(doc.did) # >> "g.1234/03eed607-acb0-4532-b0ee-9e3766b1aa6e"
 ```

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -312,7 +312,9 @@ class IndexClient(object):
         try:
             return resp.json()
         except ValueError as err:
-            reason = json.dumps({"error": "invalid json payload returned: {}".format(err)})
+            reason = json.dumps(
+                {"error": "invalid json payload returned: {}".format(err)}
+            )
             raise BaseIndexError(resp.status_code, reason)
 
     # DEPRECATED 11/2019 -- interacts with old `/alias/` endpoint.

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import warnings
 
 import requests
 
@@ -284,6 +285,10 @@ class IndexClient(object):
         )
         return Document(self, resp.json()["did"])
 
+    # DEPRECATED 11/2019 -- interacts with old `/alias/` endpoint.
+    # For creating aliases for indexd records, prefer using
+    # the `add_alias_for_did` function, which interacts with the new
+    # `/index/{GUID}/aliases` endpoint.
     def create_alias(
         self,
         record,
@@ -294,6 +299,14 @@ class IndexClient(object):
         host_authorities=None,
         keeper_authority=None,
     ):
+        warnings.warn(
+            (
+                "This function is deprecated. For creating aliases for indexd "
+                "records, prefer using the `add_alias_for_did` function, which "
+                "interacts with the new `/index/{GUID}/aliases` endpoint."
+            ),
+            DeprecationWarning,
+        )
         data = json_dumps(
             {
                 "size": size,

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -285,6 +285,21 @@ class IndexClient(object):
         )
         return Document(self, resp.json()["did"])
 
+    def add_alias_for_did(self, alias, did):
+        """
+        Adds an alias for a document id (did). Once an alias is created for
+        a did, the document can be retrieved by the alias using the 
+        `global_get(alias)` function.
+        """
+        alias_payload = {"aliases": [{"value": alias}]}
+        resp = self._post(
+            "index/{}/aliases/".format(did),
+            headers={"content-type": "application/json"},
+            data=json.dumps(alias_payload),
+            auth=self.auth,
+        )
+        return resp
+
     # DEPRECATED 11/2019 -- interacts with old `/alias/` endpoint.
     # For creating aliases for indexd records, prefer using
     # the `add_alias_for_did` function, which interacts with the new

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -4,6 +4,8 @@ import warnings
 
 import requests
 
+from indexclient.errors import BaseIndexError
+
 MAX_RETRIES = 10
 
 UPDATABLE_ATTRS = [
@@ -290,6 +292,15 @@ class IndexClient(object):
         Adds an alias for a document id (did). Once an alias is created for
         a did, the document can be retrieved by the alias using the 
         `global_get(alias)` function.
+
+
+        :param str alias:
+            The alias we want to assign to the document id.
+        :param str did:
+            The document id for the index record we want to alias.
+
+        :raises BaseIndexError:
+            Raised if aliasing operation fails.
         """
         alias_payload = {"aliases": [{"value": alias}]}
         resp = self._post(
@@ -298,7 +309,9 @@ class IndexClient(object):
             data=json.dumps(alias_payload),
             auth=self.auth,
         )
-        return resp
+        if resp.status_code != 200:
+            raise BaseIndexError(resp.status_code, resp.text)
+        return
 
     # DEPRECATED 11/2019 -- interacts with old `/alias/` endpoint.
     # For creating aliases for indexd records, prefer using

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -309,9 +309,11 @@ class IndexClient(object):
             data=json.dumps(alias_payload),
             auth=self.auth,
         )
-        if resp.status_code != 200:
-            raise BaseIndexError(resp.status_code, resp.text)
-        return
+        try:
+            return resp.json()
+        except ValueError as err:
+            reason = json.dumps({"error": "invalid json payload returned: {}".format(err)})
+            raise BaseIndexError(resp.status_code, reason)
 
     # DEPRECATED 11/2019 -- interacts with old `/alias/` endpoint.
     # For creating aliases for indexd records, prefer using

--- a/indexclient/parsers/info.py
+++ b/indexclient/parsers/info.py
@@ -2,16 +2,29 @@ import sys
 import json
 import logging
 import argparse
+import warnings
 
 import requests
 
 from indexclient import errors
 
 
+# DEPRECATED 11/2019 -- interacts with old `/alias/` endpoint.
+# For creating aliases for indexd records, prefer using
+# the `add_alias` function, which interacts with the new
+# `/index/{GUID}/aliases` endpoint.
 def info(host, port, name, **kwargs):
     """
     Retrieve info by name.
     """
+    warnings.warn(
+        (
+            "This function is deprecated. For creating aliases for indexd "
+            "records, prefer using the `add_alias_for_did` function, which "
+            "interacts with the new `/index/{GUID}/aliases` endpoint."
+        ),
+        DeprecationWarning,
+    )
     resource = "http://{host}:{port}/alias/{name}".format(
         host=host, port=port, name=name
     )

--- a/indexclient/parsers/name.py
+++ b/indexclient/parsers/name.py
@@ -1,18 +1,31 @@
 import sys
 import json
 import argparse
+import warnings
 
 import requests
 
 from indexclient import errors
 
 
+# DEPRECATED 11/2019 -- interacts with old `/alias/` endpoint.
+# For creating aliases for indexd records, prefer using
+# the `add_alias` function, which interacts with the new
+# `/index/{GUID}/aliases` endpoint.
 def name_record(
     host, port, name, rev, size, hashes, release, metadata, hosts, keeper, **kwargs
 ):
     """
     Alias a record.
     """
+    warnings.warn(
+        (
+            "This function is deprecated. For creating aliases for indexd "
+            "records, prefer using the `add_alias_for_did` function, which "
+            "interacts with the new `/index/{GUID}/aliases` endpoint."
+        ),
+        DeprecationWarning,
+    )
     resource = "http://{host}:{port}/alias/{name}".format(
         host=host, port=port, name=name
     )

--- a/indexclient/parsers/search.py
+++ b/indexclient/parsers/search.py
@@ -2,6 +2,7 @@ import sys
 import json
 import logging
 import argparse
+import warnings
 
 import requests
 
@@ -54,10 +55,22 @@ def search_record(host, port, limit, start, size, hashes, **kwargs):
     sys.stdout.write(json.dumps(doc))
 
 
+# DEPRECATED 11/2019 -- interacts with old `/alias/` endpoint.
+# For creating aliases for indexd records, prefer using
+# the `add_alias` function, which interacts with the new
+# `/index/{GUID}/aliases` endpoint.
 def search_names(host, port, limit, start, size, hashes, **kwargs):
     """
     Finds records matching specified search criteria.
     """
+    warnings.warn(
+        (
+            "This function is deprecated. For creating aliases for indexd "
+            "records, prefer using the `add_alias_for_did` function, which "
+            "interacts with the new `/index/{GUID}/aliases` endpoint."
+        ),
+        DeprecationWarning,
+    )
     if size is not None and size < 0:
         raise ValueError("size must be non-negative")
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="indexclient",
-    version="1.6.1",
+    version="2.0.0",
     packages=["indexclient", "indexclient.parsers"],
     install_requires=["requests>=2.5.2,<3.0.0"],
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,7 @@ gen3rbac==0.1.2
 
 -e git+https://github.com/uc-cdis/cdisutils-test.git@fdc53fb3d5333d53f625f0f0712eaa2fa19c803f#egg=cdisutilstest
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.1.7#egg=cdispyutils
--e git+https://github.com/uc-cdis/indexd.git@28fa621a924952be902628cfc5c1186bda38e922#egg=indexd
+-e git+https://github.com/uc-cdis/indexd.git@master#egg=indexd
 -e git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
 -e git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
 -e git+https://github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,7 @@ gen3rbac==0.1.2
 
 -e git+https://github.com/uc-cdis/cdisutils-test.git@fdc53fb3d5333d53f625f0f0712eaa2fa19c803f#egg=cdisutilstest
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.1.7#egg=cdispyutils
--e git+https://github.com/uc-cdis/indexd.git@master#egg=indexd
+-e git+https://github.com/uc-cdis/indexd.git@2.3.0#egg=indexd
 -e git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
 -e git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient
 -e git+https://github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -217,5 +217,10 @@ def test_add_alias_for_did(index_client):
     # Confirm that we can retrieve the original document using this alias
     # on the global_get endpoint
     doc = index_client.global_get(alias)
-    assert doc is not None, "Failed to retrieve document {} using alias {}".format(did, alias)
-    assert doc.did == did, "Retrieved incorrect document {}, expected {}".format(did, alias)
+    assert doc is not None, "Failed to retrieve document {} using alias {}".format(
+        did, alias
+    )
+    assert doc.did == did, "Retrieved incorrect document {}, expected {}".format(
+        did, alias
+    )
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -212,8 +212,7 @@ def test_add_alias_for_did(index_client):
 
     # Add an alias for the did using indexclient
     alias = "test_alias_123"
-    res = index_client.add_alias_for_did(alias, did)
-    assert res.status_code == 200, res.text
+    index_client.add_alias_for_did(alias, did)
 
     # Confirm that we can retrieve the original document using this alias
     # on the global_get endpoint

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -223,4 +223,3 @@ def test_add_alias_for_did(index_client):
     assert doc.did == did, "Retrieved incorrect document {}, expected {}".format(
         did, alias
     )
-

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -203,3 +203,20 @@ def test_bulk_request(index_client):
     docs = index_client.bulk_request(dids)
     for doc in docs:
         assert doc.did in dids
+
+
+def test_add_alias_for_did(index_client):
+
+    # Create a record in indexd and retrieve the did
+    did = create_random_index(index_client).did
+
+    # Add an alias for the did using indexclient
+    alias = "test_alias_123"
+    res = index_client.add_alias_for_did(alias, did)
+    assert res.status_code == 200, res.text
+
+    # Confirm that we can retrieve the original document using this alias
+    # on the global_get endpoint
+    doc = index_client.global_get(alias)
+    assert doc is not None, f"Failed to retrieve document {did} using alias {alias}"
+    assert doc.did == did, f"Retrieved incorrect document {doc.did}, expected {did}"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -218,5 +218,5 @@ def test_add_alias_for_did(index_client):
     # Confirm that we can retrieve the original document using this alias
     # on the global_get endpoint
     doc = index_client.global_get(alias)
-    assert doc is not None, f"Failed to retrieve document {did} using alias {alias}"
-    assert doc.did == did, f"Retrieved incorrect document {doc.did}, expected {did}"
+    assert doc is not None, "Failed to retrieve document {} using alias {}".format(did, alias)
+    assert doc.did == did, "Retrieved incorrect document {}, expected {}".format(did, alias)


### PR DESCRIPTION
- Adds a function `IndexClient.add_alias_for_did` to alias an indexd record using the new indexd aliasing system (https://github.com/uc-cdis/indexd/blob/master/docs/aliases.md) 
- Deprecates the functions that use the deprecated indexd aliasing system: `IndexClient.create_alias`, `parsers.info`, `parsers.name_record`, and `parsers.search_names`.

### New Features
- Added support for new `indexd` aliasing system in `indexclient`

### Improvements
- Updated documentation for `indexclient`

### Breaking Changes
- Indexclient no longer supports Python2.
