### PR TITLE
Fix alias call hitting wrong endpoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: git@github.com:Yelp/detect-secrets
-    rev: v0.13.1
+    rev: v1.4.0
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
@@ -12,6 +12,6 @@ repos:
     -   id: no-commit-to-branch
         args: [--branch, develop, --branch, master, --pattern, release/.*]
 -   repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 22.12.0
     hooks:
     -   id: black

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,8 +1,4 @@
 {
-  "exclude": {
-    "files": null,
-    "lines": null
-  },
   "generated_at": "2020-07-20T20:19:41Z",
   "plugins_used": [
     {
@@ -12,8 +8,8 @@
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -22,8 +18,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -60,107 +56,152 @@
   "results": {
     ".travis.yml": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": ".travis.yml",
         "hashed_secret": "c0f6a9c34a9785144815d1663bf345f32ad0d411",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
-        "type": "Base64 High Entropy String"
+        "is_secret": false
       }
     ],
     "Pipfile.lock": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "Pipfile.lock",
         "hashed_secret": "a208e4f9c74f7a205d0f4a3dee68140ce88ce818",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 4,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "Pipfile.lock",
         "hashed_secret": "6011ea66faf3039c5b29fdbaa0567c0356ff9a1c",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 125,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "Pipfile.lock",
         "hashed_secret": "640e60795f08744221f6816fe9dc949c58465256",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 130,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "Pipfile.lock",
         "hashed_secret": "d339625d7addea9138006aec1f6ca8679024e5bb",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 222,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "Pipfile.lock",
         "hashed_secret": "fb5db621cdd0255778280b17080c8dcdfb417066",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 227,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "Pipfile.lock",
         "hashed_secret": "d525d5ebd014ae5326d34dc39e47a1fce67f9991",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 245,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "Pipfile.lock",
         "hashed_secret": "2698838211dc12f77bea1c167e20e0822d59a27c",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 269,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "README.md": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "README.md",
         "hashed_secret": "4699f6728b23ee847a94d46c8c88845c0d010810",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 66,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "README.md",
         "hashed_secret": "44cc59c23214afd591bdc879f8aa22094e39424d",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 67,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "README.md",
         "hashed_secret": "b6f6eef3865774de17320e862df503a2bafff715",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 68,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "tests/test_client.py": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_client.py",
         "hashed_secret": "301918c8b904630da85e75ee32e9ba68ff925b73",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 42,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_client.py",
         "hashed_secret": "27860ead00d0b07e86f0819703c8ea31113025a4",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 58,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ]
   },
-  "version": "0.13.1",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "version": "1.4.0",
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    }
+  ]
 }

--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -175,7 +175,7 @@ class IndexClient(object):
         return Document(self, did, json=json)
 
     def list(self, limit=float("inf"), start=None, page_size=100):
-        """ Returns a generator of document objects. """
+        """Returns a generator of document objects."""
         return self.list_with_params(limit, start, page_size)
 
     def list_with_params(
@@ -304,7 +304,7 @@ class IndexClient(object):
         """
         alias_payload = {"aliases": [{"value": alias}]}
         resp = self._post(
-            "index/{}/aliases/".format(did),
+            "index/{}/aliases".format(did),
             headers={"content-type": "application/json"},
             data=json.dumps(alias_payload),
             auth=self.auth,
@@ -488,7 +488,7 @@ class Document(object):
         return json
 
     def _load(self, json=None):
-        """ Load the document contents from the server or from the provided dictionary """
+        """Load the document contents from the server or from the provided dictionary"""
         self._check_deleted()
         json = json or self.client._get("index", self.did).json()
         # set attributes to current Document


### PR DESCRIPTION

### Bug Fixes
- `add_alias_for_did()` now hits `POST /index/<guid>/aliases` instead of `POST /index/<guid>/aliases/`. The trailing slash was causing indexd to interpret the calls as hits to the `POST /index/<guid>` endpoint.
