### PR TITLE
adds auth to all gets

### DIFF
--- a/indexclient/client.py
+++ b/indexclient/client.py
@@ -407,6 +407,8 @@ class IndexClient(object):
 
     @retry_and_timeout_wrapper
     def _get(self, *path, **kwargs):
+        if self.auth and 'auth' not in kwargs:
+            kwargs['auth'] = self.auth
         resp = requests.get(self.url_for(*path), **kwargs)
         handle_error(resp)
         return resp


### PR DESCRIPTION
## TL-DR: This PR:

* ensures that all `get` requests to indexd have an auth header
* See https://github.com/uc-cdis/indexd/pull/400

---

## 🛠️ PR #82 — Ensure `auth` Is Passed to `_get` in `IndexClient.get`

### Summary

This PR updates the `IndexClient.get()` method to pass the client’s `auth` object explicitly when calling the internal `_get()` function. This change is necessary for compatibility with [[uc-cdis/indexd#400](https://github.com/uc-cdis/indexd/pull/400)](https://github.com/uc-cdis/indexd/pull/400), which adds support for a feature flag that enforces access control by filtering results based on the user’s `authz` permissions. Without this fix, `indexclient` fails to propagate credentials, resulting in 403 errors even when the user is authorized.

### Use Case

**As a** developer or service interacting with Indexd via `indexclient`,
**I want** all GET requests to automatically include the `auth` parameter from the `IndexClient` instance,
**So that** access-controlled records can be retrieved successfully in secured Gen3 environments.

This is essential in deployments where:

* Indexd filters responses based on `authz` (enabled via a feature flag introduced in PR #400)
* Clients rely on bearer tokens or other forms of authorization

### Changes

* Modified `IndexClient.get()` to explicitly pass `auth=self.auth` when calling `_get()`

### Before

```python
response = self._get(self._url + "/" + guid)
```

### After

```python
response = self._get(self._url + "/" + guid, auth=self.auth)
```

### Acceptance Tests

#### ✅ 1. Authorized record fetch

```python
client = IndexClient("https://my-gen3.org/index", "/v1", auth=my_auth)
doc = client.get("some-guid")
assert doc.did == "some-guid"
```

#### ✅ 2. Unauthorized access fails (expected)

```python
client = IndexClient("https://my-gen3.org/index", "/v1")
try:
    client.get("restricted-guid")
except Exception as e:
    assert "403" in str(e) or "401" in str(e)
```

#### ✅ 3. Backward compatibility for public deployments

```python
client = IndexClient("https://public-gen3.org/index", "/v1")
doc = client.get("public-guid")
assert doc.did == "public-guid"
```

